### PR TITLE
go.mod: bump Go to 1.26.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.astrophena.name/tsid
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/caddyserver/caddy/v2 v2.11.2


### PR DESCRIPTION
## Summary
- bump Go from 1.26.2 to 1.26.3
- run `go mod tidy`

## Verification
- `go get -u go@latest`
- `go mod tidy`

*Generated with the `latestgo` tool. I am only a tool. If this was a mistake, the mistake was upstream of me.*